### PR TITLE
Secret editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $ ./cmd/upsert-team-secret secrets/some-file
 To edit a secret with your default $EDITOR use `./cmd/edit-team-secret`:
 
 ```bash
-$ .cmd/edit-team-secret secrets/some-file
+$ ./cmd/edit-team-secret secrets/some-file
 ```
 
 The secret is updated when you exit your editor.

--- a/README.md
+++ b/README.md
@@ -63,24 +63,27 @@ $ ./cmd/upsert-team-secret secrets/some-file
    # ← blank line waiting for your input
 ```
 
-### Editing a secret
+### Change a secret in an editor
 
-To edit a secret with your default $EDITOR use `./cmd/edit-team-secret`:
+Use **edit-team-secret** to open a decrypted secret in a text editor
+and write the edited value back in the same encrypted file:
 
 ```bash
 $ ./cmd/edit-team-secret secrets/some-file
 ```
 
-The secret is updated when you exit your editor.
+The default editor is nano (if available) or vi.
+You can use a **different editor** by setting your shell’s `SECRET_EDITOR`
+environment variable.
+For example, if you want to edit your secrets with Visual Studio Code,
+set `SECRET_EDITOR` to `code --wait --user-data-dir /tmp`
+(`--wait` avoids the command returning immediately,
+and `--user-data-dir /tmp` ensures any backup file containing your decrypted
+secrets won’t stay on your filesystem beyond reboot):
 
-#### Warning
-Your `$EDITOR` might create some temporary files with the decrypted content.
-Please refer to your editor's documentation for how to disable that behaviour
-and other best practices. The following is a non exhaustive list of recommendations:
-
-- [vim](https://vim.fandom.com/wiki/Encryption)
-- nano: set `$EDITOR` to `nano -R`
-
+- bash: `echo 'export SECRET_EDITOR="code --wait --user-data-dir /tmp"' >>~/.bash_profile`
+- zsh (macOS): `echo 'export SECRET_EDITOR="code --wait --user-data-dir /tmp"' >>~/.zprofile`
+- fish: `set -U SECRET_EDITOR 'code --wait --user-data-dir /tmp'`
 
 ### Create a completely new vault
 

--- a/cmd/edit-team-secret
+++ b/cmd/edit-team-secret
@@ -2,6 +2,21 @@
 
 set -euf -o pipefail
 
+# ${X:-Y} returns Y when X is undefined or empty.
+# We can’t just test -z ${X} because we set -u above for safety.
+if [[ -z ${SECRET_EDITOR:-} ]]; then
+    if command -v nano >/dev/null; then
+        SECRET_EDITOR="nano --restricted --saveonexit"  # easier for the uninitiated
+    elif command -v vi >/dev/null; then
+        # POSIX, so should be there. The options likely only work for vim,
+        # to which vi likely points on most modern systems.
+        SECRET_EDITOR="vi -c 'set viminfo= | set noswapfile noundofile nobackup'"
+    else
+        echo 1>&2 "Error: SECRET_EDITOR not set, and neither nano nor vi available."
+        exit 1
+    fi
+fi
+
 DIR="$(cd $(dirname "$0")/.. && pwd)"
 
 TMP_FILE=$(mktemp)
@@ -17,6 +32,6 @@ function cleanup()
 # make sure the decrypted file is deleted
 trap cleanup EXIT
 
-$EDITOR $TMP_FILE
+$SECRET_EDITOR $TMP_FILE
 
 "$DIR"/cmd/upsert-team-secret "$1" <$TMP_FILE

--- a/cmd/edit-team-secret
+++ b/cmd/edit-team-secret
@@ -4,10 +4,6 @@ set -euf -o pipefail
 
 DIR="$(cd $(dirname "$0")/.. && pwd)"
 
-ID="$DIR/.my-secret-identity"
-
-TEAM_FILE="$DIR/team.identities"
-
 TMP_FILE=$(mktemp)
 
 function cleanup()
@@ -17,13 +13,11 @@ function cleanup()
     rm -f $TMP_FILE*
 }
 
-
-age --decrypt --identity "$ID" "$1" > $TMP_FILE
+"$DIR"/cmd/read-team-secret "$1" >$TMP_FILE
 
 # make sure the decrypted file is deleted
 trap cleanup EXIT
 
 $EDITOR $TMP_FILE
 
-cat $TMP_FILE | age --encrypt --recipients-file "$TEAM_FILE" --output "$1"
-
+"$DIR"/cmd/upsert-team-secret "$1" <$TMP_FILE

--- a/cmd/edit-team-secret
+++ b/cmd/edit-team-secret
@@ -19,18 +19,17 @@ fi
 
 DIR="$(cd $(dirname "$0")/.. && pwd)"
 
-TMP_FILE=$(mktemp)
-
 function cleanup()
 {
     # try to remove possible backup files too
     rm -f $TMP_FILE*
 }
 
-"$DIR"/cmd/read-team-secret "$1" >$TMP_FILE
-
+TMP_FILE=$(mktemp)
 # make sure the decrypted file is deleted
 trap cleanup EXIT
+
+"$DIR"/cmd/read-team-secret "$1" >$TMP_FILE
 
 $SECRET_EDITOR $TMP_FILE
 

--- a/cmd/edit-team-secret
+++ b/cmd/edit-team-secret
@@ -8,8 +8,7 @@ TMP_FILE=$(mktemp)
 
 function cleanup()
 {
-    rm $TMP_FILE
-    # try to remove backup files
+    # try to remove possible backup files too
     rm -f $TMP_FILE*
 }
 

--- a/cmd/enroll-myself-in-team-vault
+++ b/cmd/enroll-myself-in-team-vault
@@ -7,7 +7,7 @@ DIR="$(cd $(dirname "$0")/.. && pwd)"
 ID="$DIR/.my-secret-identity"
 TEAM_FILE="$DIR/team.identities"
 
-if grep -q "^# $(whoami)$" "$TEAM_FILE"; then
+if grep -q -s "^# $(whoami)$" "$TEAM_FILE"; then
     echo "$(whoami): Already listed in $(basename "$TEAM_FILE"), skipping."
     exit 1
 fi


### PR DESCRIPTION
Makes `edit-team-secret` use `$SECRET_EDITOR` instead of `$EDITOR`: securely editing secrets is a different use-case from editing regular files (in particular the editor’s backup features should be disabled), and users with an already-set `EDITOR` are unlikely to update it to something secure for that one use-case (it would likely make their experience in all other use-cases worse). Using a different variable allows the script to provide secure defaults while still letting users customize it explicitly for that separate use-case.

Other improvements unrelated to `$SECRET_EDITOR`:
- Rely on `read-team-secret` and `upsert-team-secret` instead of reimplementing them.
- Always delete the temporary file (keeping it when read-team-secret fails does not bring benefits, might make `/tmp` more crowded if it occurs repeatedly).
- `enroll-myself-in-team-vault` doesn’t print a useless message when the team.identities file doesn’t exist yet.