### PR TITLE
reencrypt-all-team-secrets: Support nested directories

### DIFF
--- a/cmd/reencrypt-all-team-secrets
+++ b/cmd/reencrypt-all-team-secrets
@@ -6,11 +6,8 @@ SECRETS_DIR="$1"
 
 DIR="$(cd $(dirname "$0")/.. && pwd)"
 
-ID="$DIR/.my-secret-identity"
-TEAM_FILE="$DIR/team.identities"
-
 find "$SECRETS_DIR" -type f -print | while read -r file; do
-    age --decrypt --identity $ID "$file" | "$DIR"/cmd/upsert-team-secret "$file"
+    "$DIR"/cmd/read-team-secret "$file" | "$DIR"/cmd/upsert-team-secret "$file"
 done
 
 echo "Done!"

--- a/cmd/reencrypt-all-team-secrets
+++ b/cmd/reencrypt-all-team-secrets
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-set -eu -o pipefail
-shopt -s failglob
+set -euf -o pipefail
 
 SECRETS_DIR="$1"
 
@@ -10,7 +9,7 @@ DIR="$(cd $(dirname "$0")/.. && pwd)"
 ID="$DIR/.my-secret-identity"
 TEAM_FILE="$DIR/team.identities"
 
-for file in "$SECRETS_DIR"/*; do
+find "$SECRETS_DIR" -type f -print | while read -r file; do
     age --decrypt --identity $ID "$file" | "$DIR"/cmd/upsert-team-secret "$file"
 done
 


### PR DESCRIPTION
Improvements to `reencrypt-all-team-secrets`:

- Support subdirectories in the secret directory: list files to reencrypt using `find` instead of a glob.
- Reuse `read-team-secret` instead of directly calling `age` (maintenance).